### PR TITLE
ログインとアカウント登録画面で入力欄が改行できてしまう問題の修正

### DIFF
--- a/app/src/main/java/io/github/akiomik/seiun/ui/login/LoginScreen.kt
+++ b/app/src/main/java/io/github/akiomik/seiun/ui/login/LoginScreen.kt
@@ -55,7 +55,8 @@ private fun LoginForm(onLoginSuccess: () -> Unit) {
             label = { Text("Handle") },
             placeholder = { Text(text = "jack.bsky.social") },
             maxLines = 1,
-            modifier = Modifier.padding(20.dp)
+            modifier = Modifier.padding(20.dp),
+            singleLine = true
         )
 
         TextField(
@@ -68,7 +69,8 @@ private fun LoginForm(onLoginSuccess: () -> Unit) {
             maxLines = 1,
             visualTransformation = PasswordVisualTransformation(),
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-            modifier = Modifier.padding(20.dp)
+            modifier = Modifier.padding(20.dp),
+            singleLine = true
         )
 
         ElevatedButton(

--- a/app/src/main/java/io/github/akiomik/seiun/ui/registration/RegistrationScreen.kt
+++ b/app/src/main/java/io/github/akiomik/seiun/ui/registration/RegistrationScreen.kt
@@ -45,7 +45,8 @@ fun RegistrationForm(onRegistrationSuccess: () -> Unit) {
             placeholder = { Text(text = "jack@example.com") },
             maxLines = 1,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
-            modifier = Modifier.padding(20.dp)
+            modifier = Modifier.padding(20.dp),
+            singleLine = true
         )
 
         TextField(
@@ -57,7 +58,8 @@ fun RegistrationForm(onRegistrationSuccess: () -> Unit) {
             prefix = { Text(text = "@") },
             suffix = { Text(text = ".bsky.social") },
             maxLines = 1,
-            modifier = Modifier.padding(20.dp)
+            modifier = Modifier.padding(20.dp),
+            singleLine = true
         )
 
         TextField(
@@ -67,7 +69,8 @@ fun RegistrationForm(onRegistrationSuccess: () -> Unit) {
             maxLines = 1,
             visualTransformation = PasswordVisualTransformation(),
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-            modifier = Modifier.padding(20.dp)
+            modifier = Modifier.padding(20.dp),
+            singleLine = true
         )
 
         TextField(
@@ -77,7 +80,8 @@ fun RegistrationForm(onRegistrationSuccess: () -> Unit) {
             placeholder = { Text(text = "bsky.social-XXXXXX") },
             maxLines = 1,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
-            modifier = Modifier.padding(20.dp)
+            modifier = Modifier.padding(20.dp),
+            singleLine = true
         )
 
         ElevatedButton(


### PR DESCRIPTION
改行が入力されてしまい、ログイン・アカウント登録時に意図しない文字列が入力されてしまうため、改行が行えないように変更した。