### PR TITLE
fix: date formatting in FeedPost

### DIFF
--- a/app/src/main/java/io/github/akiomik/seiun/ui/timeline/FeedPost.kt
+++ b/app/src/main/java/io/github/akiomik/seiun/ui/timeline/FeedPost.kt
@@ -219,7 +219,7 @@ private fun FeedPostContent(viewPost: FeedViewPost) {
         }
         Text(
             modifier = Modifier.padding(bottom = 4.dp),
-            text = DateFormat.format("yyyy/mm/dd hh:mm", createdAt.toEpochMilli()).toString(),
+            text = DateFormat.format("yyyy/MM/dd hh:mm", createdAt.toEpochMilli()).toString(),
             color = Color.Gray,
             style = MaterialTheme.typography.labelMedium
         )


### PR DESCRIPTION
The month part of the post date in `FeedPost` is not shown correctly (the minute part is shown instead).