### PR TITLE
Update:ログインと新規登録画面で入力欄を広げ、ボタンを右寄せに変更する

### DIFF
--- a/app/src/main/java/io/github/akiomik/seiun/ui/login/LoginScreen.kt
+++ b/app/src/main/java/io/github/akiomik/seiun/ui/login/LoginScreen.kt
@@ -70,7 +70,9 @@ private fun LoginForm(onLoginSuccess: () -> Unit) {
             placeholder = { Text(text = stringResource(id = R.string.login_handle_or_email_placeholder)) },
             maxLines = 1,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
-            modifier = Modifier.padding(20.dp),
+            modifier = Modifier
+                .padding(20.dp)
+                .fillMaxWidth(),
             singleLine = true
         )
 
@@ -84,7 +86,9 @@ private fun LoginForm(onLoginSuccess: () -> Unit) {
             maxLines = 1,
             visualTransformation = PasswordVisualTransformation(),
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-            modifier = Modifier.padding(20.dp),
+            modifier = Modifier
+                .padding(20.dp)
+                .fillMaxWidth(),
             singleLine = true
         )
 

--- a/app/src/main/java/io/github/akiomik/seiun/ui/login/LoginScreen.kt
+++ b/app/src/main/java/io/github/akiomik/seiun/ui/login/LoginScreen.kt
@@ -114,7 +114,9 @@ private fun LoginForm(onLoginSuccess: () -> Unit) {
                 )
             },
             enabled = valid,
-            modifier = Modifier.padding(20.dp)
+            modifier = Modifier
+                .padding(20.dp)
+                .align(alignment = Alignment.End)
 
         ) {
             Text(stringResource(id = R.string.login_button))
@@ -125,8 +127,11 @@ private fun LoginForm(onLoginSuccess: () -> Unit) {
 @Composable
 private fun CreateAccountButton(onClick: () -> Unit) {
     Row(
-        modifier = Modifier.padding(20.dp),
-        verticalAlignment = Alignment.CenterVertically
+        modifier = Modifier
+            .padding(20.dp)
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.End
     ) {
         Text(stringResource(id = R.string.login_or), modifier = Modifier.padding(bottom = 2.dp))
         TextButton(onClick = onClick) {

--- a/app/src/main/java/io/github/akiomik/seiun/ui/registration/RegistrationScreen.kt
+++ b/app/src/main/java/io/github/akiomik/seiun/ui/registration/RegistrationScreen.kt
@@ -3,10 +3,12 @@ package io.github.akiomik.seiun.ui.registration
 import android.util.Log
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
@@ -51,7 +53,9 @@ fun RegistrationForm(onRegistrationSuccess: () -> Unit) {
             placeholder = { Text(text = stringResource(id = R.string.registration_email_placeholder)) },
             maxLines = 1,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
-            modifier = Modifier.padding(20.dp),
+            modifier = Modifier
+                .padding(20.dp)
+                .fillMaxWidth(),
             singleLine = true
         )
 
@@ -64,7 +68,9 @@ fun RegistrationForm(onRegistrationSuccess: () -> Unit) {
             prefix = { Text(text = "@") },
             suffix = { Text(text = ".bsky.social") },
             maxLines = 1,
-            modifier = Modifier.padding(20.dp),
+            modifier = Modifier
+                .padding(20.dp)
+                .fillMaxWidth(),
             singleLine = true
         )
 
@@ -75,7 +81,9 @@ fun RegistrationForm(onRegistrationSuccess: () -> Unit) {
             maxLines = 1,
             visualTransformation = PasswordVisualTransformation(),
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-            modifier = Modifier.padding(20.dp),
+            modifier = Modifier
+                .padding(20.dp)
+                .fillMaxWidth(),
             singleLine = true
         )
 
@@ -86,7 +94,9 @@ fun RegistrationForm(onRegistrationSuccess: () -> Unit) {
             placeholder = { Text(text = "bsky.social-XXXXXX") },
             maxLines = 1,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
-            modifier = Modifier.padding(20.dp),
+            modifier = Modifier
+                .padding(20.dp)
+                .fillMaxWidth(),
             singleLine = true
         )
 

--- a/app/src/main/java/io/github/akiomik/seiun/ui/registration/RegistrationScreen.kt
+++ b/app/src/main/java/io/github/akiomik/seiun/ui/registration/RegistrationScreen.kt
@@ -124,7 +124,9 @@ fun RegistrationForm(onRegistrationSuccess: () -> Unit) {
                 )
             },
             enabled = valid,
-            modifier = Modifier.padding(20.dp)
+            modifier = Modifier
+                .padding(20.dp)
+                .align(alignment = Alignment.End)
         ) {
             Text(stringResource(id = R.string.registration_button))
         }


### PR DESCRIPTION
ログインと新規登録画面にて入力欄の幅が指定されていないようなので、画面幅に広げた。
また、それに合わせてログインボタン等を右寄せに変更した。