### PR TITLE
Fix reply error

### DIFF
--- a/app/src/main/java/io/github/akiomik/seiun/repository/TimelineRepository.kt
+++ b/app/src/main/java/io/github/akiomik/seiun/repository/TimelineRepository.kt
@@ -119,7 +119,7 @@ class TimelineRepository(private val authRepository: AuthRepository) : Applicati
         val record = Post(text = content, createdAt = Date(), reply = to, embed = embed)
 
         return RequestHelper.executeWithRetry(authRepository) {
-            val body = CreateRecordInput(did = it.did, record = record, collection = "")
+            val body = CreateRecordInput(did = it.did, record = record, collection = "app.bsky.feed.post")
             getAtpClient().createPost(authorization = "Bearer ${it.accessJwt}", body = body)
         }
     }


### PR DESCRIPTION
Fix error `java.io.IOException: Lexicon not found: lex:` on sending reply.
**Probably** createReply collection needs "app.bsky.fed.post”.